### PR TITLE
⚡ Fix clicks table schema and turned to full-refresh

### DIFF
--- a/tap_impact/schemas/clicks.json
+++ b/tap_impact/schemas/clicks.json
@@ -42,7 +42,7 @@
     "customer_city": {
       "type": ["null", "string"]
     },
-    "customer_country\"": {
+    "customer_country": {
       "type": ["null", "string"]
     },
     "customer_region": {

--- a/tap_impact/streams.py
+++ b/tap_impact/streams.py
@@ -72,10 +72,8 @@ STREAMS = {
                 'path': 'Campaigns/{}/Clicks',
                 'data_key': 'Clicks',
                 'key_properties': ['id'],
-                'replication_method': 'INCREMENTAL',
-                'replication_keys': ['event_date'],
-                'bookmark_type': 'datetime',
-                'bookmark_query_field': 'Date'
+                'replication_method': 'FULL_TABLE',
+                'bookmark_type': 'datetime'
             },
             'contacts': {
                 'path': 'Campaigns/{}/Contacts',


### PR DESCRIPTION
This can be summarised as a change of coding the singer impact tap's behavior. This change was made to collect a full snapshot of click data on every sync, for all campaigns